### PR TITLE
ES-10: Fixed AttributeError: module 'cinder.volume.driver' has no attribute 'ExtendVD'

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -30,7 +30,6 @@ from cinder.i18n import _
 from cinder.image import image_utils
 from cinder import interface
 from cinder import utils
-from cinder.volume import driver
 from cinder.volume.drivers import remotefs as remotefs_drv
 
 LOG = logging.getLogger(__name__)
@@ -53,8 +52,7 @@ CONF.register_opts(volume_opts)
 
 
 @interface.volumedriver
-class LustreDriver(remotefs_drv.RemoteFSSnapDriverDistributed,
-                   driver.ExtendVD):
+class LustreDriver(remotefs_drv.RemoteFSSnapDriverDistributed):
     """Lustre based cinder driver.
 
     Creates file on Lustre share for using it as block device on hypervisor.


### PR DESCRIPTION
**ES-10: Fixed AttributeError: module 'cinder.volume.driver' has no attribute 'ExtendVD'**

Based on [upstream commit](https://opendev.org/openstack/cinder/commit/2c8b3d457d903d1f3ab98311d9d5371e5a5c0ecd):
```
    commit 2c8b3d457d903d1f3ab98311d9d5371e5a5c0ecd
    Author: Ivan Kolodyazhny <e0ne@e0ne.info>
    Date:   Fri Sep 15 10:34:41 2017 -0600

        Remove deprecated VD base classes which are not used now

        Change-Id: I171022c0af01f4216c30630be7487f6f53d5fbca
```