### PR TITLE
ERROR cinder.volume.drivers.lustre Exception during mounting 'LustreDriver' object has no attribute '_ensure_share_writable'

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -393,8 +393,6 @@ class LustreDriver(remotefs_drv.RemoteFSSnapDriverDistributed):
             cmd = ['chmod', 'g+w', mount_path]
             self._execute(*cmd, run_as_root=True)
 
-        self._ensure_share_writable(mount_path)
-
     def _find_share(self, volume_size_for):
         """Choose Lustre share among available ones for given volume size.
 


### PR DESCRIPTION
**ERROR cinder.volume.drivers.lustre Exception during mounting 'LustreDriver' object has no attribute '_ensure_share_writable'**

Based on upstream commit:
```
    commit 1fb342cba89e63d15dde9db2136bdf34b549e559
    Author: Alan Bishop <abishop@redhat.com>
    Date:   Mon Dec 10 15:18:56 2018 -0500

        Fix permissions with NFS-backed snapshots and backups

        Fix snapshot issues that occur if cinder does not have regular (non-root)
        write permission on an NFS share. This is done by following the volume
        driver's model of creating files as root, followed by calling
        _set_rw_permissions().

        Fix backup issues that occur if cinder's group ID changes, which can
        happen when migrating from bare metal to a containerized service. If the
        share's group ownership and permission needs to be modified, then do it
        recursively so that previously made backups remain accessible.

        Closes-Bug: #1807760
        Change-Id: I6c20c4825af0a365b6a20fb633c810c2f2fe48b0
```