### PR TITLE
Fixed ERROR cinder.volume.drivers.lustre Unauthorized command: umount /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01 (no filter matched)

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -29,6 +29,7 @@ from cinder import exception
 from cinder.i18n import _
 from cinder.image import image_utils
 from cinder import interface
+from cinder.privsep import fs
 from cinder import utils
 from cinder.volume.drivers import remotefs as remotefs_drv
 
@@ -111,9 +112,8 @@ class LustreDriver(remotefs_drv.RemoteFSSnapDriverDistributed):
 
     def _do_umount(self, ignore_not_mounted, share):
         mount_path = self._get_mount_point_for_share(share)
-        command = ['umount', mount_path]
         try:
-            self._execute(*command, run_as_root=True)
+            fs.umount(mount_path)
         except processutils.ProcessExecutionError as exc:
             if ignore_not_mounted and 'not mounted' in exc.stderr:
                 LOG.info("%s is already umounted", share)


### PR DESCRIPTION
**Fixed ERROR cinder.volume.drivers.lustre Unauthorized command: umount /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01 (no filter matched)**

Based on upstream commit:
```
    commit 923fc520744271f0431f8e39797b081263ed4f13
    Author: Chuck Short <chucks@redhat.com>
    Date:   Thu Oct 18 11:35:27 2018 -0400

        Remove umount from volume.filters

        Use umount to umount volumes via oslo.privsep.

        Change-Id: I83972fbfaf0842800c65ed8c391e2089de9807fe
        Signed-off-by: Chuck Short <chucks@redhat.com>
```