### PR TITLE
ES-14 Lustre volume creation error: qemu-img: Failed to unlock byte 100

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -46,6 +46,9 @@ volume_opts = [
     cfg.StrOpt('lustre_mount_point_base',
                default='$state_path/mnt',
                help='Base dir containing mount points for lustre shares.'),
+    cfg.StrOpt('lustre_mount_options',
+               default='flock',
+               help='Comma-separated string of Lustre mount options.')
 ]
 
 CONF = cfg.CONF
@@ -95,6 +98,11 @@ class LustreDriver(remotefs_drv.RemoteFSSnapDriverDistributed):
         self.base = getattr(self.configuration,
                             'lustre_mount_point_base',
                             CONF.lustre_mount_point_base)
+        mount_options = getattr(self.configuration,
+                                'lustre_mount_options',
+                                CONF.lustre_mount_options)
+        if mount_options:
+            self.configuration.nas_mount_options = '-o %s' % mount_options
 
     def do_setup(self, context):
         """Any initialization the volume driver does while starting."""


### PR DESCRIPTION
**ES-14 Lustre volume creation error: qemu-img: Failed to unlock byte 100**

h3. Reference
Current versions of OpenStack/LibVirt use locks when working with Cinder volume files:
```
commit 244a5668106297378391b768e7288eb157616f64
Author: Fam Zheng <famz@redhat.com>
Date:   Wed May 3 00:35:56 2017 +0800

   file-posix: Add image locking to perm operations

   This extends the permission bits of op blocker API to external using
   Linux OFD locks.

   Each permission in @perm and @shared_perm is represented by a locked
   byte in the image file.  Requesting a permission in @perm is translated
   to a shared lock of the corresponding byte; rejecting to share the same
   permission is translated to a shared lock of a separate byte. With that,
   we use 2x number of bytes of distinct permission types.

   virtlockd in libvirt locks the first byte, so we do locking from a
   higher offset.

   Suggested-by: Kevin Wolf <kwolf@redhat.com>
   Signed-off-by: Fam Zheng <famz@redhat.com>
   Signed-off-by: Kevin Wolf <kwolf@redhat.com>

```

It seems that we always need to use the mount option which enables locks.
So we need to add mount options to the driver.

Test with proposed patch:
```
Jul 03 15:44:19 openstack-master-ns5-nfs cinder-volume[106355]: DEBUG cinder.volume.drivers.lustre [None req-62cf0605-5f22-40ab-a65f-a2004843bd4b admin None] cre
ating new volume at /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01/volume-548b62d5-80b8-4f37-b165-c3dc536548fd {{_do_create_volume /opt/stack/cinder
/cinder/volume/drivers/lustre.py:356}}
Jul 03 15:44:19 openstack-master-ns5-nfs cinder-volume[106355]: DEBUG oslo_concurrency.processutils [None req-62cf0605-5f22-40ab-a65f-a2004843bd4b admin None] Ru
nning cmd (subprocess): sudo cinder-rootwrap /etc/cinder/rootwrap.conf qemu-img create -f qcow2 -o preallocation=metadata /opt/stack/data/cinder/mnt/b54f7ac8a4ce
2147da2fb48a62928b01/volume-548b62d5-80b8-4f37-b165-c3dc536548fd 107374182400 {{execute /usr/local/lib/python3.6/dist-packages/oslo_concurrency/processutils.py:371}}
Jul 03 15:44:19 openstack-master-ns5-nfs sudo[106788]:    stack : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/local/bin/cinder-rootwrap /etc/cinder/rootwrap.conf qemu-img create -f qcow2 -o preallocation=metadata /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01/volume-548b62d5-80b8-4f37-b165-c3dc536548fd 107374182400
Jul 03 15:44:19 openstack-master-ns5-nfs sudo[106788]: pam_unix(sudo:session): session opened for user root by (uid=0)
Jul 03 15:44:20 openstack-master-ns5-nfs sudo[106788]: pam_unix(sudo:session): session closed for user root
Jul 03 15:44:20 openstack-master-ns5-nfs cinder-volume[106355]: DEBUG oslo_concurrency.processutils [None req-62cf0605-5f22-40ab-a65f-a2004843bd4b admin None] CMD "sudo cinder-rootwrap /etc/cinder/rootwrap.conf qemu-img create -f qcow2 -o preallocation=metadata /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01/volume-548b62d5-80b8-4f37-b165-c3dc536548fd 107374182400" returned: 0 in 0.874s {{execute /usr/local/lib/python3.6/dist-packages/oslo_concurrency/processutils.py:408}}
Jul 03 15:44:20 openstack-master-ns5-nfs cinder-volume[106355]: DEBUG oslo_concurrency.processutils [None req-62cf0605-5f22-40ab-a65f-a2004843bd4b admin None] Running cmd (subprocess): sudo cinder-rootwrap /etc/cinder/rootwrap.conf chmod ugo+rw /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01/volume-548b62d5-80b8-4f37-b165-c3dc536548fd {{execute /usr/local/lib/python3.6/dist-packages/oslo_concurrency/processutils.py:371}}
Jul 03 15:44:20 openstack-master-ns5-nfs sudo[106798]:    stack : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/local/bin/cinder-rootwrap /etc/cinder/rootwrap.conf chmod ugo+rw /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01/volume-548b62d5-80b8-4f37-b165-c3dc536548fd
Jul 03 15:44:20 openstack-master-ns5-nfs sudo[106798]: pam_unix(sudo:session): session opened for user root by (uid=0)
Jul 03 15:44:20 openstack-master-ns5-nfs sudo[106798]: pam_unix(sudo:session): session closed for user root
Jul 03 15:44:20 openstack-master-ns5-nfs cinder-volume[106355]: DEBUG oslo_concurrency.processutils [None req-62cf0605-5f22-40ab-a65f-a2004843bd4b admin None] CMD "sudo cinder-rootwrap /etc/cinder/rootwrap.conf chmod ugo+rw /opt/stack/data/cinder/mnt/b54f7ac8a4ce2147da2fb48a62928b01/volume-548b62d5-80b8-4f37-b165-c3dc536548fd" returned: 0 in 0.204s {{execute /usr/local/lib/python3.6/dist-packages/oslo_concurrency/processutils.py:408}}
Jul 03 15:44:20 openstack-master-ns5-nfs cinder-volume[106355]: DEBUG cinder.coordination [None req-62cf0605-5f22-40ab-a65f-a2004843bd4b admin None] Lock "/opt/stack/data/cinder/cinder-lustre-548b62d5-80b8-4f37-b165-c3dc536548fd" released by "create_volume" :: held 1.316s {{_synchronized /opt/stack/cinder/cinder/coordination.py:162}}
```