### PR TITLE
ES-17 Lustre volume from snapshot creation TypeError: _copy_volume_from_snapshot() takes 4 positional arguments but 6 were given

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -209,7 +209,9 @@ class LustreDriver(remotefs_drv.RemoteFSSnapDriverDistributed):
 
         return {'provider_location': volume.provider_location}
 
-    def _copy_volume_from_snapshot(self, snapshot, volume, volume_size):
+    def _copy_volume_from_snapshot(self, snapshot, volume, volume_size,
+                                   src_encryption_key_id=None,
+                                   new_encryption_key_id=None):
         # """Copy data from snapshot to destination volume.
 
         # This is done with a qemu-img convert to raw/qcow2 from the snapshot


### PR DESCRIPTION
**ES-17 Lustre volume from snapshot creation TypeError: _copy_volume_from_snapshot() takes 4 positional arguments but 6 were given**

Based on upstream commit:
```
commit 44c7da9a44cc235b514e1b714cc7882683a8491d
Author: Eric Harney <eharney@redhat.com>
Date:   Wed Aug 29 15:20:40 2018 -0400

    NFS encrypted volume support
    
    Volume encryption helps provide basic data protection in
    case the volume back-end is either compromised or outright
    stolen. The contents of an encrypted volume can only be
    read with the use of a specific key;
    
    Volume encryption: Check volume encryption key in
    '_do_create_volume' method (remotefs) and use
    '_create_encrypted_volume_file' when encryption is
    required.
    
    Snapshot encryption: To create an encrypted volume from a
    snapshot, we need to pass the Barbican key of the
    snapshot.volume to 'convert_image' method. Because of this
    I've added 'src_passphrase_file' parameter.
    
    This patch doesn't handle encrypted volume -> unencrypted
    Current error prompted: 'Invalid input received: Invalid
    volume_type provided: aeac5517-6bc8-4b59-9eb2-76e84369bd0
    (requested type is not compatible; recommend omitting the
    type argument). (HTTP 400)'
    
    Implements: blueprint nfs-volume-encryption
    Co-Authored-By: Sofia Enriquez <lsofia.enriquez@gmail.com>
    
    Change-Id: I896f70d204ad103e968ab242ba9045ca984827c4
```