### PR TITLE
ES-35 Lustre Cinder driver incorrectly cleans resources

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -329,6 +329,29 @@ class LustreDriver(remotefs.RemoteFSSnapDriverDistributed):
         """Disallow connection from connector."""
         pass
 
+    def delete_volume(self, volume):
+        """Deletes a logical volume."""
+
+        LOG.debug('Deleting volume %(vol)s, provider_location: %(loc)s',
+                  {'vol': volume.id, 'loc': volume.provider_location})
+
+        if not volume.provider_location:
+            LOG.warning('Volume %s does not have provider_location '
+                        'specified, skipping', volume.name)
+            return
+
+        info_path = self._local_path_volume_info(volume)
+        info = self._read_info_file(info_path, empty_if_missing=True)
+
+        if info:
+            base_volume_path = os.path.join(self._local_volume_dir(volume),
+                                            info['active'])
+            self._delete(info_path)
+        else:
+            base_volume_path = self._local_path_volume(volume)
+
+        self._delete(base_volume_path)
+
     def extend_volume(self, volume, new_size):
         """Extend an existing volume to the new size."""
 


### PR DESCRIPTION
**ES-35 Lustre Cinder driver incorrectly cleans resources**

```
======
Totals
======
Ran: 263 tests in 0.1146 sec.
 - Passed: 254
 - Skipped: 9
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 6055.2365 sec.
```