### PR TITLE
ES-36 Lustre Cinder driver failed to revert snapshot: Snapshot status must be "available" or "backing-up" to clone. But is: restoring

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -82,7 +82,8 @@ class LustreNoSharesMounted(exception.RemoteFSNoSharesMounted):
 
 
 @interface.volumedriver
-class LustreDriver(remotefs.RemoteFSSnapDriverDistributed):
+class LustreDriver(remotefs.RevertToSnapshotMixin,
+                   remotefs.RemoteFSSnapDriverDistributed):
     """Lustre based cinder driver.
 
     Creates file on Lustre share for using it as block device on hypervisor.


### PR DESCRIPTION
**ES-36 Lustre Cinder driver failed to revert snapshot: Snapshot status must be "available" or "backing-up" to clone. But is: restoring**