### PR TITLE
ES-37 Lustre Cinder driver failed to (un)manage volume: NotImplementedError: Unmanage volume not implemented.

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -83,6 +83,7 @@ class LustreNoSharesMounted(exception.RemoteFSNoSharesMounted):
 
 @interface.volumedriver
 class LustreDriver(remotefs.RevertToSnapshotMixin,
+                   remotefs.RemoteFSManageableVolumesMixin,
                    remotefs.RemoteFSSnapDriverDistributed):
     """Lustre based cinder driver.
 


### PR DESCRIPTION
**ES-37 Lustre Cinder driver failed to (un)manage volume: NotImplementedError: Unmanage volume not implemented.**