### PR TITLE
ES-39 Lustre backup service failed to start: TypeError: __init__() got an unexpected keyword argument 'db'

### DIFF
--- a/cinder/backup/drivers/lustre.py
+++ b/cinder/backup/drivers/lustre.py
@@ -45,7 +45,7 @@ CONF.register_opts(lustrebackup_service_opts)
 class LustreBackupDriver(posix.PosixBackupDriver):
     """Provides backup, restore and delete using Lustre repository."""
 
-    def __init__(self, context, db_driver=None):
+    def __init__(self, context, db=None):
         self._check_configuration()
         self.backup_mount_point_base = CONF.lustre_backup_mount_point
         self.backup_share = CONF.lustre_backup_share


### PR DESCRIPTION
**ES-39 Lustre backup service failed to start: TypeError: __init__() got an unexpected keyword argument 'db'**