### PR TITLE
ES-40 Lustre backup driver mounts the backup share endlessly

### DIFF
--- a/cinder/backup/drivers/lustre.py
+++ b/cinder/backup/drivers/lustre.py
@@ -18,11 +18,12 @@
 import os
 import stat
 
-from os_brick.remotefs import remotefs as remotefs_brick
-from oslo_concurrency import processutils as putils
+from os_brick.remotefs import remotefs
+from oslo_concurrency import processutils
 from oslo_config import cfg
 
 from cinder.backup.drivers import posix
+from cinder import coordination
 from cinder import exception
 from cinder import interface
 from cinder import utils
@@ -31,7 +32,7 @@ from cinder import utils
 lustrebackup_service_opts = [
     cfg.StrOpt('lustre_backup_mount_point',
                default='$state_path/backup_mount',
-               help='Base dir containing mount point for lustre share.'),
+               help='Base dir containing mount point for Lustre share.'),
     cfg.StrOpt('lustre_backup_share',
                help='Lustre share in <hostname|ip>@tcp:/<fsname> format. '
                     'Eg: 1.2.3.4@tcp:/backup_vol'),
@@ -46,49 +47,47 @@ class LustreBackupDriver(posix.PosixBackupDriver):
     """Provides backup, restore and delete using Lustre repository."""
 
     def __init__(self, context, db=None):
-        self._check_configuration()
+        self.mount_type = 'lustre'
         self.backup_mount_point_base = CONF.lustre_backup_mount_point
         self.backup_share = CONF.lustre_backup_share
-        self._execute = putils.execute
+        self.check_for_setup_error()
+        self._execute = processutils.execute
         self._root_helper = utils.get_root_helper()
         backup_path = self._init_backup_repo_path()
         super(LustreBackupDriver, self).__init__(context,
                                                  backup_path=backup_path)
 
     @staticmethod
-    def _check_configuration():
-        """Raises error if any required configuration flag is missing."""
-        required_flags = ['lustre_backup_share']
-        for flag in required_flags:
-            if not getattr(CONF, flag, None):
-                raise exception.ConfigNotFound(path=flag)
+    def get_driver_options():
+        return lustrebackup_service_opts
 
+    def check_for_setup_error(self):
+        """Raises error if any required configuration flag is missing."""
+        options = ['lustre_backup_mount_point', 'lustre_backup_share']
+        for option in options:
+            value = getattr(CONF, option, None)
+            if not value:
+                raise exception.InvalidConfigurationValue(option=option,
+                                                          value=value)
+
+    @coordination.synchronized('{self.mount_type}-{self.backup_share}')
     def _init_backup_repo_path(self):
-        remotefsclient = remotefs_brick.RemoteFsClient(
-            'lustre',
+        remotefsclient = remotefs.RemoteFsClient(
+            self.mount_type,
             self._root_helper,
+            execute=self._execute,
             lustre_mount_point_base=self.backup_mount_point_base)
         remotefsclient.mount(self.backup_share)
-
-        # Ensure we can write to this share
         mount_path = remotefsclient.get_mount_point(self.backup_share)
-
         group_id = os.getegid()
         current_group_id = utils.get_file_gid(mount_path)
         current_mode = utils.get_file_mode(mount_path)
-
         if group_id != current_group_id:
-            cmd = ['chgrp', group_id, mount_path]
+            cmd = ['chgrp', '-R', group_id, mount_path]
             self._execute(*cmd, root_helper=self._root_helper,
                           run_as_root=True)
-
         if not (current_mode & stat.S_IWGRP):
-            cmd = ['chmod', 'g+w', mount_path]
+            cmd = ['chmod', '-R', 'g+w', mount_path]
             self._execute(*cmd, root_helper=self._root_helper,
                           run_as_root=True)
-
         return mount_path
-
-
-def get_backup_driver(context):
-    return LustreBackupDriver(context)


### PR DESCRIPTION
**ES-40 Lustre backup driver mounts the backup share endlessly**

Tempest for Lustre backup:
```
{2} tempest.api.volume.test_volumes_backup.VolumesBackupsV39Test.test_update_backup [53.796928s] ... ok
{1} tempest.api.volume.admin.test_volumes_backup.VolumesBackupsAdminTest.test_volume_backup_export_import [121.736349s] ... ok
{0} tempest.api.volume.test_volumes_backup.VolumesBackupsTest.test_backup_create_attached_volume [137.607799s] ... ok
{1} tempest.api.volume.admin.test_volumes_backup.VolumesBackupsAdminTest.test_volume_backup_reset_status [53.010468s] ... ok
{0} tempest.api.volume.test_volumes_backup.VolumesBackupsTest.test_bootable_volume_backup_and_restore [95.010266s] ... ok
{0} tempest.api.volume.test_volumes_backup.VolumesBackupsTest.test_volume_backup_create_get_detailed_list_restore_delete [93.827211s] ... ok

======
Totals
======
Ran: 6 tests in 326.4472 sec.
 - Passed: 6
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 554.9890 sec.

```