### PR TITLE
ES-41 Lustre Cinder driver failed on pep8 tests

### DIFF
--- a/cinder/opts.py
+++ b/cinder/opts.py
@@ -36,6 +36,7 @@ from cinder.backup import driver as cinder_backup_driver
 from cinder.backup.drivers import ceph as cinder_backup_drivers_ceph
 from cinder.backup.drivers import gcs as cinder_backup_drivers_gcs
 from cinder.backup.drivers import glusterfs as cinder_backup_drivers_glusterfs
+from cinder.backup.drivers import lustre as cinder_backup_drivers_lustre
 from cinder.backup.drivers import nfs as cinder_backup_drivers_nfs
 from cinder.backup.drivers import posix as cinder_backup_drivers_posix
 from cinder.backup.drivers import swift as cinder_backup_drivers_swift
@@ -122,6 +123,7 @@ from cinder.volume.drivers.lenovo import lenovo_common as \
     cinder_volume_drivers_lenovo_lenovocommon
 from cinder.volume.drivers import linstordrv as \
     cinder_volume_drivers_linstordrv
+from cinder.volume.drivers import lustre as cinder_volume_drivers_lustre
 from cinder.volume.drivers import lvm as cinder_volume_drivers_lvm
 from cinder.volume.drivers.macrosan import driver as \
     cinder_volume_drivers_macrosan_driver
@@ -205,6 +207,7 @@ def list_opts():
                 cinder_backup_drivers_ceph.service_opts,
                 cinder_backup_drivers_gcs.gcsbackup_service_opts,
                 cinder_backup_drivers_glusterfs.glusterfsbackup_service_opts,
+                cinder_backup_drivers_lustre.lustrebackup_service_opts,
                 cinder_backup_drivers_nfs.nfsbackup_service_opts,
                 cinder_backup_drivers_posix.posixbackup_service_opts,
                 cinder_backup_drivers_swift.swiftbackup_service_opts,
@@ -260,6 +263,7 @@ def list_opts():
                 instorage_mcs_opts,
                 cinder_volume_drivers_inspur_instorage_instorageiscsi.
                 instorage_mcs_iscsi_opts,
+                cinder_volume_drivers_lustre.lustre_opts,
                 cinder_volume_drivers_sandstone_sdsdriver.sds_opts,
                 cinder_volume_drivers_veritas_access_veritasiscsi.VA_VOL_OPTS,
                 cinder_volume_manager.volume_manager_opts,

--- a/cinder/tests/unit/volume/drivers/test_lustre.py
+++ b/cinder/tests/unit/volume/drivers/test_lustre.py
@@ -16,16 +16,16 @@
 
 import errno
 import os
-import six
 import tempfile
 import time
 import traceback
+from unittest import mock
 
-import mock
 import os_brick
 from oslo_concurrency import processutils as putils
 from oslo_utils import imageutils
 from oslo_utils import units
+import six
 
 from cinder import compute
 from cinder import context
@@ -40,7 +40,6 @@ from cinder import utils
 from cinder.volume import driver as base_driver
 from cinder.volume.drivers import lustre
 from cinder.volume.drivers import remotefs as remotefs_drv
-from os_brick.remotefs import remotefs as remotefs_brick
 
 
 class FakeDb(object):
@@ -97,7 +96,7 @@ class LustreDriverTestCase(test.TestCase):
                                 db=FakeDb())
         self._driver.shares = {}
         root_helper = utils.get_root_helper()
-        self._driver._remotefsclient = remotefs_brick.RemoteFsClient(
+        self._driver._remotefsclient = os_brick.remotefs.RemoteFsClient(
             'lustre', root_helper, putils.execute,
             lustre_mount_point_base=self.TEST_MNT_POINT_BASE)
         compute.API = mock.MagicMock()
@@ -568,7 +567,8 @@ class LustreDriverTestCase(test.TestCase):
                 mock_ensure_share_mounted,\
                 mock.patch.object(self._driver, '_local_volume_dir') as \
                 mock_local_volume_dir,\
-                mock.patch.object(self._driver, 'get_active_image_from_info') as \
+                mock.patch.object(self._driver,
+                                  'get_active_image_from_info') as \
                 mock_active_image_from_info,\
                 mock.patch.object(self._driver, '_execute') as \
                 mock_execute,\
@@ -976,9 +976,11 @@ class LustreDriverTestCase(test.TestCase):
         snap_path = '%s.%s' % (volume_path, self.SNAP_UUID)
         snap_file = '%s.%s' % (volume_file, self.SNAP_UUID)
 
-        with mock.patch.object(drv, '_do_create_snapshot') as mock_do_create_snapshot,\
-                mock.patch.object(db, 'snapshot_get') as mock_snapshot_get,\
-                mock.patch.object(drv, '_nova') as mock_nova,\
+        with mock.patch.object(drv, '_do_create_snapshot') as \
+                mock_do_create_snapshot, \
+                mock.patch.object(db, 'snapshot_get') as \
+                mock_snapshot_get, \
+                mock.patch.object(drv, '_nova') as mock_nova, \
                 mock.patch.object(time, 'sleep') as mock_sleep:
 
             mock_snapshot_get.side_effect = SideEffectList(


### PR DESCRIPTION
**ES-41 Lustre Cinder driver failed on pep8 tests**

**pep8 tests**
```
pep8 start: run-test-pre 
pep8 run-test-pre: PYTHONHASHSEED='1149808347'
pep8 finish: run-test-pre  after 0.00 seconds
pep8 start: run-test 
pep8 run-test: commands[0] | flake8 .
setting PATH=/opt/stack/develop/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[102064] /opt/stack/develop/cinder$ /opt/stack/develop/cinder/.tox/pep8/bin/flake8 .
pep8 run-test: commands[1] | doc8
setting PATH=/opt/stack/develop/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[102166] /opt/stack/develop/cinder$ /opt/stack/develop/cinder/.tox/pep8/bin/doc8
Scanning...
Validating...
========
Total files scanned = 195
Total files ignored = 443
Total accumulated errors = 0
Detailed error counts:
    - doc8.checks.CheckCarriageReturn = 0
    - doc8.checks.CheckIndentationNoTab = 0
    - doc8.checks.CheckMaxLineLength = 0
    - doc8.checks.CheckNewlineEndOfFile = 0
    - doc8.checks.CheckTrailingWhitespace = 0
    - doc8.checks.CheckValidity = 0
pep8 run-test: commands[2] | /opt/stack/develop/cinder/tools/config/check_uptodate.sh
setting PATH=/opt/stack/develop/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[102217] /opt/stack/develop/cinder$ /opt/stack/develop/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[3] | /opt/stack/develop/cinder/tools/check_exec.py /opt/stack/develop/cinder/cinder /opt/stack/develop/cinder/doc/source/ /opt/stack/develop/cinder/releasenotes/notes
setting PATH=/opt/stack/develop/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[102236] /opt/stack/develop/cinder$ /opt/stack/develop/cinder/tools/check_exec.py cinder doc/source releasenotes/notes
pep8 finish: run-test  after 65.90 seconds
pep8 start: run-test-post 
pep8 finish: run-test-post  after 0.00 seconds
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)

```