### PR TITLE
ES-44 Refactor Lustre Cinder driver

### DIFF
--- a/cinder/volume/drivers/lustre.py
+++ b/cinder/volume/drivers/lustre.py
@@ -62,7 +62,7 @@ lustre_opts = [
                      'In such case volume creation takes a lot of time.'),
     cfg.BoolOpt('lustre_qcow2_volumes',
                 default=False,
-                help='Create volumes as QCOW2 files rather than raw files.')
+                help='Create volumes as qcow2 files rather than raw files.')
 ]
 
 CONF = cfg.CONF
@@ -98,33 +98,33 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
     driver_prefix = 'lustre'
     volume_backend_name = 'Lustre'
     VERSION = '1.0.0'
-
-    # ThirdPartySystems wiki page
     CI_WIKI_NAME = "Lustre_CI"
 
     def __init__(self, execute=processutils.execute, *args, **kwargs):
         self._remotefsclient = None
         super(LustreDriver, self).__init__(*args, **kwargs)
-        self.configuration.append_config_values(lustre_opts)
         root_helper = utils.get_root_helper()
+        self.configuration.append_config_values(lustre_opts)
         self.configuration.nas_host = getattr(self.configuration,
                                               'lustre_share_host',
                                               CONF.lustre_share_host)
         self.configuration.nas_share_path = getattr(self.configuration,
                                                     'lustre_share_path',
                                                     CONF.lustre_share_path)
-        self.base = getattr(self.configuration,
-                            'lustre_mount_point_base',
-                            CONF.lustre_mount_point_base)
-        self.base = os.path.realpath(self.base)
-        lustre_mount_options = getattr(self.configuration,
-                                       'lustre_mount_options',
-                                       CONF.lustre_mount_options)
-
+        mount_point_base = getattr(self.configuration,
+                                   'lustre_mount_point_base',
+                                   CONF.lustre_mount_point_base)
+        mount_point_base = os.path.realpath(mount_point_base)
+        mount_options = getattr(self.configuration,
+                                'lustre_mount_options',
+                                CONF.lustre_mount_options)
         self._remotefsclient = remotefs_brick.RemoteFsClient(
             self.driver_volume_type, root_helper, execute=execute,
-            lustre_mount_point_base=self.base,
-            lustre_mount_options=lustre_mount_options)
+            lustre_mount_point_base=mount_point_base,
+            lustre_mount_options=mount_options)
+        self.base = mount_point_base
+        if mount_options:
+            self.configuration.nas_mount_options = '-o %s' % mount_options
         self._sparse_copy_volume_data = True
         self._supports_encryption = True
         self.reserved_percentage = self.configuration.reserved_percentage
@@ -139,26 +139,27 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
         return lustre_opts
 
     def check_for_setup_error(self):
-        package = 'mount.lustre'
+        lustre_package = 'lustre-client'
+        lustre_mount = 'mount.lustre'
         try:
-            self._execute(package, check_exit_code=False)
-        except OSError as exc:
-            if exc.errno == errno.ENOENT:
-                msg = _('Package %s is not installed') % package
-                raise LustreException(msg)
+            self._execute(lustre_mount, check_exit_code=False)
+        except OSError as error:
+            if error.errno == errno.ENOENT:
+                message = (_('Required package %(lustre_package)s '
+                             'is not installed: %(error_reason)s')
+                           % {'lustre_package': lustre_package,
+                              'error_reason': error.strerror})
+                raise LustreException(message)
             raise
         self._refresh_mounts()
 
     def _unmount_shares(self):
         self._load_shares_config()
         for share in self.shares:
-            try:
-                self._do_umount(True, share)
-            except Exception as exc:
-                LOG.warning('Exception during unmounting %s', exc)
+            self._do_umount(share)
 
     @coordination.synchronized('{self.driver_prefix}-{share}')
-    def _do_umount(self, ignore_not_mounted, share):
+    def _do_umount(self, share):
         mntpoints = self._remotefsclient._read_mounts()
         mntpoint = self._get_mount_point_for_share(share)
         if mntpoint not in mntpoints:
@@ -167,10 +168,12 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
             return
         try:
             fs.umount(mntpoint)
-        except processutils.ProcessExecutionError as exc:
-            if 'target is busy' in exc.stderr:
-                LOG.warning("Failed to refresh mounts, reason=%s",
-                            exc.stderr)
+        except processutils.ProcessExecutionError as error:
+            if error.exit_code in [errno.EPIPE, errno.EBUSY]:
+                LOG.warning('Failed to unmount Lustre share %(share)s '
+                            'mounted at %(mntpoint)s: %(error_reason)s',
+                            {'share': share, 'mntpoint': mntpoint,
+                             'error_reason': error.stderr})
             else:
                 raise
 
@@ -187,16 +190,13 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
         """Retrieve stats info from volume group."""
         super(LustreDriver, self)._update_volume_stats()
         data = self._stats
-
         global_capacity = data['total_capacity_gb']
         global_free = data['free_capacity_gb']
-
         thin_enabled = self.configuration.lustre_sparsed_volumes
         if thin_enabled:
             provisioned_capacity = self._get_provisioned_capacity()
         else:
             provisioned_capacity = round(global_capacity - global_free, 2)
-
         data['provisioned_capacity_gb'] = provisioned_capacity
         data['max_over_subscription_ratio'] = (
             self.configuration.max_over_subscription_ratio)
@@ -205,7 +205,6 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
         data['thick_provisioning_support'] = not thin_enabled
         data['multiattach'] = not self.configuration.lustre_qcow2_volumes
         data['sparse_copy_volume'] = True
-
         self._stats = data
 
     def _copy_volume_from_snapshot(self, snapshot, volume, volume_size,
@@ -216,62 +215,49 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
         This is done with a qemu-img convert to raw/qcow2 from the snapshot
         qcow2.
         """
-
-        LOG.debug("Copying snapshot: %(snap)s -> volume: %(vol)s, "
-                  "volume_size: %(size)s GB",
-                  {'snap': snapshot.id,
-                   'vol': volume.id,
-                   'size': volume_size})
-
+        LOG.debug('Copying snapshot: %(snapshot)s -> volume: %(volume)s, '
+                  'volume size: %(volume_size)s GB',
+                  {'snapshot': snapshot.id,
+                   'volume': volume.id,
+                   'volume_size': volume_size})
         info_path = self._local_path_volume_info(snapshot.volume)
         snap_info = self._read_info_file(info_path)
         vol_path = self._local_volume_dir(snapshot.volume)
         forward_file = snap_info[snapshot.id]
         forward_path = os.path.join(vol_path, forward_file)
-
-        # Find the file which backs this file, which represents the point
-        # when this snapshot was created.
         img_info = self._qemu_img_info(forward_path, snapshot.volume.name)
         path_to_snap_img = os.path.join(vol_path, img_info.backing_file)
-
         path_to_new_vol = self._local_path_volume(volume)
-
-        LOG.debug("will copy from snapshot at %s", path_to_snap_img)
-
         if self.configuration.lustre_qcow2_volumes:
-            out_format = 'qcow2'
+            volume_format = 'qcow2'
         else:
-            out_format = 'raw'
-
+            volume_format = 'raw'
         if new_encryption_key_id is not None:
             if src_encryption_key_id is None:
-                message = _("Can't create an encrypted volume %(format)s "
-                            "from an unencrypted source."
-                            ) % {'format': out_format}
+                message = (_('Failed to create an encrypted %(format)s '
+                             'volume %(volume)s from an unencrypted '
+                             'source snapshot %(snapshot)s.')
+                           % {'format': volume_format,
+                              'volume': volume.id,
+                              'snapshot': snapshot.id})
                 LOG.error(message)
-                # TODO(enriquetaso): handle unencrypted snap->encrypted vol
-                raise exception.NfsException(message)
+                raise LustreException(message)
             keymgr = key_manager.API(CONF)
             new_key = keymgr.get(volume.obj_context, new_encryption_key_id)
-            new_passphrase = \
-                binascii.hexlify(new_key.get_encoded()).decode('utf-8')
-
-            # volume.obj_context is the owner of this request
+            new_passphrase = (
+                binascii.hexlify(new_key.get_encoded()).decode('utf-8'))
             src_key = keymgr.get(volume.obj_context, src_encryption_key_id)
-            src_passphrase = \
-                binascii.hexlify(src_key.get_encoded()).decode('utf-8')
-
+            src_passphrase = (
+                binascii.hexlify(src_key.get_encoded()).decode('utf-8'))
             tmp_dir = volume_utils.image_conversion_dir()
             with tempfile.NamedTemporaryFile(prefix='luks_',
                                              dir=tmp_dir) as src_pass_file:
                 with open(src_pass_file.name, 'w') as f:
                     f.write(src_passphrase)
-
                 with tempfile.NamedTemporaryFile(prefix='luks_',
                                                  dir=tmp_dir) as new_pass_file:
                     with open(new_pass_file.name, 'w') as f:
                         f.write(new_passphrase)
-
                     image_utils.convert_image(
                         path_to_snap_img,
                         path_to_new_vol,
@@ -282,14 +268,12 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
         else:
             image_utils.convert_image(path_to_snap_img,
                                       path_to_new_vol,
-                                      out_format,
+                                      volume_format,
                                       run_as_root=self._execute_as_root)
-
         self._set_rw_permissions_for_all(path_to_new_vol)
 
     def ensure_export(self, ctx, volume):
         """Synchronously recreates an export for a logical volume."""
-
         self._ensure_share_mounted(volume.provider_location)
 
     def create_export(self, ctx, volume, connector):
@@ -298,80 +282,97 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
 
     def remove_export(self, ctx, volume):
         """Removes an export for a logical volume."""
-
         pass
 
     def validate_connector(self, connector):
         pass
 
-    @coordination.synchronized('{self.driver_prefix}-{volume[id]}')
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
     def initialize_connection(self, volume, connector):
         """Allow connection to connector and return connection info."""
-
-        # Find active qcow2 file
-        active_file = self.get_active_image_from_info(volume)
-        path = '%s/%s/%s' % (self.base,
-                             self._get_hash_str(volume.provider_location),
-                             active_file)
-
-        data = {'export': volume.provider_location,
-                'name': active_file}
-        if volume.provider_location in self.shares:
-            data['options'] = self.shares[volume.provider_location]
-
-        # Test file for raw vs. qcow2 format
-        info = self._qemu_img_info(path, volume.name)
-        data['format'] = info.file_format
-        if data['format'] not in ['raw', 'qcow2']:
-            msg = _('%s must be a valid raw or qcow2 image.') % path
-            raise exception.InvalidVolume(msg)
-
-        return {
-            'driver_volume_type': self.driver_volume_type,
-            'data': data,
-            'mount_point_base': self._get_mount_point_base()
+        LOG.debug('Initializing connection to volume %(volume)s '
+                  'and connector: %(connector)s',
+                  {'volume': volume.id, 'connector': connector})
+        volume_dir = self._local_volume_dir(volume)
+        volume_file = self.get_active_image_from_info(volume)
+        volume_path = os.path.join(volume_dir, volume_file)
+        volume_info = self._qemu_img_info(volume_path, volume.name)
+        volume_format = volume_info.file_format
+        if volume_format not in ['raw', 'qcow2']:
+            message = (_('%(volume_type)s volume file %(volume_path)s '
+                         'must be a valid raw or qcow2 image. '
+                         'But is: %(volume_format)s')
+                       % {'volume_type': self.driver_volume_type,
+                          'volume_path': volume_path,
+                          'volume_format': volume_format})
+            raise exception.InvalidVolume(message)
+        data = {
+            'export': volume.provider_location,
+            'format': volume_format,
+            'name': volume_file
         }
+        if self.shares.get(volume.provider_location):
+            data['options'] = self.shares[volume.provider_location]
+        connection_info = {
+            'driver_volume_type': self.driver_volume_type,
+            'mount_point_base': self.base,
+            'data': data
+        }
+        LOG.debug('%(volume_type)s connection info for volume '
+                  '%(volume)s: %(connection_info)s',
+                  {'volume_type': self.driver_volume_type,
+                   'volume': volume.id,
+                   'connection_info': connection_info})
+        return connection_info
 
     def terminate_connection(self, volume, connector, **kwargs):
         """Disallow connection from connector."""
         pass
 
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
+    def create_volume(self, volume):
+        """Apply locking to the create volume operation."""
+        return super(LustreDriver, self).create_volume(volume)
+
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
     def delete_volume(self, volume):
         """Deletes a logical volume."""
-
-        LOG.debug('Deleting volume %(vol)s, provider_location: %(loc)s',
-                  {'vol': volume.id, 'loc': volume.provider_location})
-
+        LOG.debug('Deleting volume %(volume)s with provider '
+                  'location: %(location)s',
+                  {'volume': volume.id,
+                   'location': volume.provider_location})
         if not volume.provider_location:
-            LOG.warning('Volume %s does not have provider_location '
-                        'specified, skipping', volume.name)
+            LOG.warning('Volume %(volume)s does not have provider '
+                        'location specified, skipping',
+                        {'volume': volume.id})
             return
-
         info_path = self._local_path_volume_info(volume)
         info = self._read_info_file(info_path, empty_if_missing=True)
-
-        if info:
-            base_volume_path = os.path.join(self._local_volume_dir(volume),
-                                            info['active'])
+        if info.get('active'):
+            volume_dir = self._local_volume_dir(volume)
+            volume_path = os.path.join(volume_dir, info['active'])
             self._delete(info_path)
         else:
-            base_volume_path = self._local_path_volume(volume)
+            volume_path = self._local_path_volume(volume)
+        self._delete(volume_path)
 
-        self._delete(base_volume_path)
-
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
     def extend_volume(self, volume, new_size):
         """Extend an existing volume to the new size."""
 
         LOG.info('Extending volume %(volume)s to %(size)sG.',
-                 {'volume': volume.name, 'size': new_size})
+                 {'volume': volume.id, 'size': new_size})
         path = self.local_path(volume)
         image_utils.resize_image(path, new_size,
                                  run_as_root=self._execute_as_root)
         info = self._qemu_img_info(path, volume.name)
         size = info.virtual_size / units.Gi
         if size != new_size:
-            raise exception.ExtendVolumeError(
-                reason='Resizing image file failed.')
+            reason = (_('Failed to extend volume %(volume)s, expected '
+                        'volume size %(new_size)sG but got %(size)sG')
+                      % {'volume': volume.id, 'new_size': new_size,
+                         'size': size})
+            raise exception.ExtendVolumeError(reason=reason)
 
     @coordination.synchronized('{self.driver_prefix}-{share}')
     def _ensure_share_mounted(self, share):
@@ -379,19 +380,14 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
 
         :param share: string
         """
+        self._remotefsclient.mount(share)
         mount_path = self._get_mount_point_for_share(share)
-        self._mount_lustre(share)
-
-        # TODO(deiter): secure NAS/mount_attempts
-        # Ensure we can write to this share
         group_id = os.getegid()
         current_group_id = utils.get_file_gid(mount_path)
         current_mode = utils.get_file_mode(mount_path)
-
         if group_id != current_group_id:
             cmd = ['chgrp', group_id, mount_path]
             self._execute(*cmd, run_as_root=True)
-
         if not (current_mode & stat.S_IWGRP):
             cmd = ['chmod', 'g+w', mount_path]
             self._execute(*cmd, run_as_root=True)
@@ -404,40 +400,22 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
 
         :param volume: the volume to be created.
         """
-
         if not self._mounted_shares:
             raise LustreNoSharesMounted()
-
         target_share = None
         target_available = 0
-
         for share in self._mounted_shares:
             available = self._get_available_capacity(share)[0]
             if available > target_available:
                 target_share = share
                 target_available = available
-
         if volume.size * units.Gi > target_available:
             raise LustreNoSuitableShareFound(volume_size=volume.size)
-
         LOG.debug('Selected %(share)s as target Lustre '
                   'share to create volume %(volume)s.',
                   {'share': target_share,
                    'volume': volume.name})
-
         return target_share
-
-    def _mount_lustre(self, lustre_share):
-        """Mount Lustre share to mount path."""
-        mnt_flags = []
-        if self.shares.get(lustre_share) is not None:
-            mnt_flags = self.shares[lustre_share].split()
-        try:
-            self._remotefsclient.mount(lustre_share, mnt_flags)
-        except processutils.ProcessExecutionError:
-            LOG.error("Mount failure for %(share)s.",
-                      {'share': lustre_share})
-            raise
 
     # Workaround for ES-32
     def _create_volume_from_snapshot(self, volume, snapshot):
@@ -445,29 +423,21 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
 
         Snapshot must not be the active snapshot. (offline)
         """
-
         LOG.debug('Creating volume %(vol)s from snapshot %(snap)s',
                   {'vol': volume.id, 'snap': snapshot.id})
-
         if snapshot.status not in ['available', 'backing-up']:
             msg = (_('Snapshot status must be "available" or '
                      '"backing-up" to clone. But is: %(status)s')
                    % {'status': snapshot.status})
-
             raise exception.InvalidSnapshot(msg)
-
         self._ensure_shares_mounted()
-
         volume.provider_location = self._find_share(volume)
-
         self._do_create_volume(volume)
-
         self._copy_volume_from_snapshot(snapshot,
                                         volume,
                                         volume.size,
                                         snapshot.volume.encryption_key_id,
                                         volume.encryption_key_id)
-
         return {'provider_location': volume.provider_location}
 
     # Workaround for ES-15
@@ -574,15 +544,12 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
 
               info file: { 'active': 'volume-1234' }  (* changed!)
         """
-
         LOG.debug('Creating %(type)s snapshot %(snap)s of volume %(vol)s',
                   {'snap': snapshot.id, 'vol': snapshot.volume.id,
                    'type': ('online'
                             if self._is_volume_attached(snapshot.volume)
                             else 'offline')})
-
         status = snapshot.volume.status
-
         acceptable_states = ['available', 'in-use', 'backing-up']
         if (snapshot.display_name and
                 snapshot.display_name.startswith('tmp-snap-')):
@@ -590,15 +557,12 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
             # image caching, we'll allow creating/deleting such snapshots
             # while having volumes in 'downloading' state.
             acceptable_states.append('downloading')
-
         self._validate_state(status, acceptable_states)
-
         info_path = self._local_path_volume_info(snapshot.volume)
         snap_info = self._read_info_file(info_path, empty_if_missing=True)
         backing_filename = self.get_active_image_from_info(
             snapshot.volume)
         new_snap_path = self._get_new_snap_path(snapshot)
-
         if self._is_volume_attached(snapshot.volume):
             self._create_snapshot_online(snapshot,
                                          backing_filename,
@@ -607,7 +571,54 @@ class LustreDriver(remotefs.RevertToSnapshotMixin,
             self._do_create_snapshot(snapshot,
                                      backing_filename,
                                      new_snap_path)
-
         snap_info['active'] = os.path.basename(new_snap_path)
         snap_info[snapshot.id] = os.path.basename(new_snap_path)
         self._write_info_file(info_path, snap_info)
+
+    @coordination.synchronized('{self.driver_prefix}-{volume.id}')
+    def update_migrated_volume(self, ctxt, volume, new_volume,
+                               original_volume_status):
+        """Return the keys and values updated for migrated volume.
+
+        This method should rename the back-end volume name(id) on the
+        destination host back to its original name(id) on the source host.
+
+        :param ctxt: The context used to run the method update_migrated_volume
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        if (original_volume_status == 'available' and
+                volume.provider_location != new_volume.provider_location):
+            current_name = CONF.volume_name_template % new_volume.id
+            original_volume_name = CONF.volume_name_template % volume.id
+            current_path = self.local_path(new_volume)
+            original_path = current_path.replace(current_name,
+                                                 original_volume_name)
+            try:
+                os.rename(current_path, original_path)
+            except OSError:
+                LOG.exception('Unable to rename the logical volume '
+                              'for volume: %s', volume.id)
+                # If the rename fails, _name_id should be set to the new
+                # volume id and provider_location should be set to the
+                # one from the new volume as well.
+                name_id = new_volume._name_id or new_volume.id
+        else:
+            # The back-end will not be renamed.
+            name_id = new_volume._name_id or new_volume.id
+        return {'_name_id': name_id,
+                'provider_location': new_volume.provider_location}
+
+    @coordination.synchronized('{self.driver_prefix}-{snapshot.volume.id}')
+    def create_snapshot(self, snapshot):
+        """Apply locking to the create snapshot operation."""
+        return self._create_snapshot(snapshot)
+
+    @coordination.synchronized('{self.driver_prefix}-{snapshot.volume.id}')
+    def delete_snapshot(self, snapshot):
+        """Apply locking to the delete snapshot operation."""
+        return self._delete_snapshot(snapshot)


### PR DESCRIPTION
**Refactor the existing Lustre Cinder driver**:
* Code cleanup
* Improve error messages
* Pass Lustre filesystem mount options to Nova via initialize_connection
* Apply locking to the create/delete volume/snapshot operations
* Update volume after generic migration